### PR TITLE
fix docker-compose-nacos-2.yml config error

### DIFF
--- a/nacos-2/docker-compose-nacos-2.yml
+++ b/nacos-2/docker-compose-nacos-2.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - "8848:8848"
       - "9555:9555"
-    networks: nacos_net
+    networks: 
+      - nacos_net
     restart: 
       - on-failure
     privileged: true


### PR DESCRIPTION
ERROR: The Compose file './docker-compose-nacos-2.yml' is invalid because:
services.docker-nacos-server.networks contains an invalid type, it should be an array, or an object
services.docker-nacos-server.restart contains an invalid type, it should be a string